### PR TITLE
Move sponsor talk to the end

### DIFF
--- a/meetups/2024/2024-02-22-talks/program.md
+++ b/meetups/2024/2024-02-22-talks/program.md
@@ -8,11 +8,11 @@ The program for the evening is:
 
 - 18:05 - 18:10: Welcome (5 min)
 - 18:15 - 19:00: "Building serverless apps, using WASI, WebAssembly components using Rust" by Mikkel Mørk Hegnhøj (45 min incl Q&A)
-- 19:00 - 19:10: A word from our sponsor (5-10 min)
-- 19:10 - 19:20: Using Rust at Partisia by Partisia (10 min)
-- 19:20 - 19:55: Light dinner sponsored by Partisia (45 min)
-- 19:55 - 20:40: "Zero-copy deserialization in Rust" by Gustav Wengel (45 min incl Q&A)
-- 20:45 - 20:55: Book Lottery (10 min)
+- 19:05 - 19:15: Using Rust at Partisia by Partisia (10 min)
+- 19:15 - 19:45: Light dinner sponsored by Partisia (30 min)
+- 19:45 - 20:30: "Zero-copy deserialization in Rust" by Gustav Wengel (45 min incl Q&A)
+- 20:35 - 20:45: Book Lottery (10 min)
+- 20:45 - 20:55: A word from our sponsor (5-10 min)
 - 20:55 - 21:00: Closing remarks (5 min)
 
 


### PR DESCRIPTION
I have moved the sponsor talk to the end, per request from Partisia.